### PR TITLE
fix: Fix 500 Error when deleting user with saved checklists and tasks

### DIFF
--- a/src/main/kotlin/ch/ascendise/todolistapi/checklist/ChecklistRepository.kt
+++ b/src/main/kotlin/ch/ascendise/todolistapi/checklist/ChecklistRepository.kt
@@ -4,8 +4,10 @@ import org.springframework.data.jpa.repository.JpaRepository
 import java.util.*
 import javax.transaction.Transactional
 
+@Transactional
 interface ChecklistRepository : JpaRepository<Checklist, Long> {
     fun findAllByUserId(userId: Long) : List<Checklist>
     fun findByIdAndUserId(id: Long, userId: Long) : Optional<Checklist>
-    @Transactional fun deleteByIdAndUserId(id: Long, userId: Long)
+    fun deleteByIdAndUserId(id: Long, userId: Long)
+
 }

--- a/src/main/kotlin/ch/ascendise/todolistapi/task/TaskRepository.kt
+++ b/src/main/kotlin/ch/ascendise/todolistapi/task/TaskRepository.kt
@@ -4,9 +4,10 @@ import org.springframework.data.jpa.repository.JpaRepository
 import java.util.*
 import javax.transaction.Transactional
 
+@Transactional
 interface TaskRepository : JpaRepository<Task, Long>
 {
     fun findAllByUserId(id: Long): List<Task>
     fun findByIdAndUserId(id: Long, userId: Long): Optional<Task>
-    @Transactional fun deleteByIdAndUserId(id: Long, userId: Long)
+    fun deleteByIdAndUserId(id: Long, userId: Long)
 }

--- a/src/main/kotlin/ch/ascendise/todolistapi/user/UserRepository.kt
+++ b/src/main/kotlin/ch/ascendise/todolistapi/user/UserRepository.kt
@@ -1,7 +1,9 @@
 package ch.ascendise.todolistapi.user
 
 import org.springframework.data.jpa.repository.JpaRepository
+import javax.transaction.Transactional
 
+@Transactional
 interface UserRepository: JpaRepository<User,Long> {
     fun findBySubject(subject: String): User
     fun existsBySubject(subject: String): Boolean

--- a/src/main/kotlin/ch/ascendise/todolistapi/user/UserService.kt
+++ b/src/main/kotlin/ch/ascendise/todolistapi/user/UserService.kt
@@ -1,17 +1,25 @@
 package ch.ascendise.todolistapi.user
 
+import ch.ascendise.todolistapi.checklist.ChecklistService
+import ch.ascendise.todolistapi.task.TaskService
 import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.stereotype.Service
 
 @Service
 class UserService(
-    val userRepository: UserRepository
+    val userRepository: UserRepository,
+    val checklistService: ChecklistService,
+    val taskService: TaskService
 ) {
 
     fun getUser(jwt: Jwt) =
         userRepository.findBySubject(jwt.subject)
 
     fun delete(user: User) {
+        checklistService.getChecklists(user.id).asSequence()
+            .forEach { checklistService.delete(it.id, user.id) }
+        taskService.getAll(user.id).asSequence()
+            .forEach { taskService.delete(user.id, it.id)}
         userRepository.delete(user)
     }
 }


### PR DESCRIPTION
Closes https://github.com/ascendise/TodolistApi/issues/24

Fixes the key constraint error when deleting user, because Hibernate does not know that the tasks and checklists belong to the user and then the user gets deleted, while the tasks still reference the now non existing user.

There probably is a more intuitive fix but for now, just removing all checklists and tasks of the user manually should suffice