### PR TITLE
Fixed illogical validation constraints of tasks

### DIFF
--- a/src/main/kotlin/ch/ascendise/todolistapi/task/TaskService.kt
+++ b/src/main/kotlin/ch/ascendise/todolistapi/task/TaskService.kt
@@ -9,11 +9,11 @@ class TaskService(
 ) {
 
     fun create(task: Task): Task {
-        validate(task)
+        validateNewTask(task)
         return taskRepository.save(task)
     }
 
-    fun validate(task: Task) {
+    fun validateNewTask(task: Task) {
         if (task.endDate?.isBefore(task.startDate) == true) {
             throw InvalidDateRangeTaskException()
         } else if(task.startDate.isBefore(LocalDate.now())) {
@@ -22,8 +22,12 @@ class TaskService(
     }
 
     fun update(task: Task): Task {
-        validate(task)
-        val oldTask = taskRepository.findByIdAndUserId(task.id, task.user.id).orElseThrow { TaskNotFoundException()}
+        val oldTask = taskRepository.findByIdAndUserId(task.id, task.user.id).orElseThrow { TaskNotFoundException() }
+        if (task.endDate?.isBefore(task.startDate) == true) {
+            throw InvalidDateRangeTaskException()
+        }else if (task.startDate.isBefore(oldTask.startDate)) {
+            throw InvalidDateRangeTaskException()
+        }
         oldTask.name = task.name
         oldTask.description = task.description
         oldTask.startDate = task.startDate


### PR DESCRIPTION
Before this, the start date of a task would have to be updated to today everytime any field gets changed. This doesn't really make sense. 
With this change, the start date can be left to the past when changing for example the name.
If the start date is changed, the new date has to be after the old date but can still be in the past