### PR TITLE
fix: Decrease image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM openjdk:17-alpine AS build
+FROM eclipse-temurin:17-jdk-alpine AS build
 WORKDIR /app
 COPY . .
 RUN ./mvnw -Dmaven.test.skip package
 
-FROM openjdk:17-alpine
+FROM eclipse-temurin:17-jre-alpine
 WORKDIR /usr/bin/todolistapi/
 COPY --from=build /app/target/todolistapi.jar ./
 RUN addgroup -S spring && adduser -S spring -G spring


### PR DESCRIPTION
Decreases image size by a few mb by only using the JRE for the final image.

Also had to change base image, because openjdk image is being deprecated