### PR TITLE
feat: validation OAuth2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ properties is generated and the placeholders have to be replaced with the real v
 ```
 spring.security.oauth2.resourceserver.jwt.issuer-uri
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri
+oauth2.audience
 ```
 
 These values are needed to register the authorization-server used for authentication. The issuer uri has to match with 
 the "iss"-claim of the JWT. The jwk-set-uri is where the app gets the info to validate the signature of your JWT.
-It should be something along the lines of "*/.well-known/jwks.json"
+It should be something along the lines of "*/.well-known/jwks.json". The ``oauth2.audience`` needs to be the same as 
+the aud-claim in the JWT.
 
 ### Datasource
 
@@ -84,8 +86,8 @@ Make sure to not have any spaces behind commas. You can also use wildcards in th
 The documentation for the API is a Swagger-page located at {your-url}/swagger-ui/index.html
 
 ### Authentication
-The API uses OAuth2 with JWTs to authenticate the user. The API should work fine with any authorization server adhering
-to the OpenIdConnect specs.
+The API uses OAuth2 with JWTs to authenticate the user. The aud-claim needs to be equal to the
+specified spring property ``oauth2.audience`` or else authorization fails with a 401 Unauthorized.
 
 ## Troubleshooting
 

--- a/application2.2yml
+++ b/application2.2yml
@@ -1,0 +1,20 @@
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: https://dev-ypizy20t.us.auth0.com/
+          jwk-set-uri:  https://dev-ypizy20t.us.auth0.com/.well-known/jwks.json
+oauth2:
+  audience: https://ascendise.todolistapi.ch
+#  jpa:
+#    hibernate:
+#      ddl-auto: "update"
+#  datasource:
+#    url: jdbc:mysql://localhost:3306/todolistdb
+#    username: spring
+#    password: lunafreya
+#    driver-class-name: "com.mysql.cj.jdbc.Driver"
+#  output:
+#    ansi:
+#      enabled: "DETECT"

--- a/src/main/kotlin/ch/ascendise/todolistapi/checklisttask/ChecklistTaskModelAssembler.kt
+++ b/src/main/kotlin/ch/ascendise/todolistapi/checklisttask/ChecklistTaskModelAssembler.kt
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component
 class ChecklistTaskModelAssembler: RepresentationModelAssembler<ChecklistTaskResponseDto, ChecklistTaskResponseDto> {
 
     override fun toModel(relation: ChecklistTaskResponseDto): ChecklistTaskResponseDto {
-        val dummyUser = User(-1, "", "")
+        val dummyUser = User(-1, "")
         return relation.add(
             linkTo<ChecklistController> { getChecklist(relation.checklistId, dummyUser) }.withRel("checklist"),
             linkTo<TaskController> { getTask(dummyUser, relation.taskId) }.withRel("task"),

--- a/src/main/kotlin/ch/ascendise/todolistapi/user/AudienceValidator.kt
+++ b/src/main/kotlin/ch/ascendise/todolistapi/user/AudienceValidator.kt
@@ -1,0 +1,17 @@
+package ch.ascendise.todolistapi.user
+
+import org.springframework.security.oauth2.core.OAuth2Error
+import org.springframework.security.oauth2.core.OAuth2TokenValidator
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult
+import org.springframework.security.oauth2.jwt.Jwt
+
+class AudienceValidator(private val audience: String) : OAuth2TokenValidator<Jwt> {
+
+    override fun validate(token: Jwt?): OAuth2TokenValidatorResult {
+        if(token == null || !token.audience.contains(audience)) {
+            val error = OAuth2Error("invalid_token", "The required audience is missing", null)
+            return OAuth2TokenValidatorResult.failure(error)
+        }
+        return OAuth2TokenValidatorResult.success()
+    }
+}

--- a/src/main/kotlin/ch/ascendise/todolistapi/user/PostAuthenticationHandler.kt
+++ b/src/main/kotlin/ch/ascendise/todolistapi/user/PostAuthenticationHandler.kt
@@ -20,7 +20,6 @@ class PostAuthenticationHandler(
     }
 
     private fun getUserInfo(jwt: Jwt) = User(
-        username = jwt.getClaimAsString("name"),
         subject = jwt.subject,
     )
 

--- a/src/main/kotlin/ch/ascendise/todolistapi/user/User.kt
+++ b/src/main/kotlin/ch/ascendise/todolistapi/user/User.kt
@@ -6,8 +6,7 @@ import javax.persistence.*
 @Entity
 class User(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY) var id: Long = 0,
-    @Column(unique = true) var subject: String,
-    @Column(unique = true) var username: String
+    @Column(unique = true) var subject: String
     ): RepresentationModel<User>() {
 
     override fun equals(other: Any?): Boolean {
@@ -18,7 +17,6 @@ class User(
 
         if (id != other.id) return false
         if (subject != other.subject) return false
-        if (username != other.username) return false
         if (links != other.links) return false
         return true
     }
@@ -26,7 +24,6 @@ class User(
     override fun hashCode(): Int {
         var result = id.hashCode()
         result = 31 * result + subject.hashCode()
-        result = 31 * result + username.hashCode()
         return result
     }
 }

--- a/src/main/resources/templates/application_template.yml
+++ b/src/main/resources/templates/application_template.yml
@@ -16,3 +16,5 @@ spring:
   output:
     ansi:
       enabled: "DETECT"
+oauth2:
+  audience: [audience]

--- a/src/test/kotlin/ch/ascendise/todolistapi/checklist/ChecklistControllerTest.kt
+++ b/src/test/kotlin/ch/ascendise/todolistapi/checklist/ChecklistControllerTest.kt
@@ -23,7 +23,7 @@ internal class ChecklistControllerTest
 
     private val checklistService = mockk<ChecklistService>()
     private val checklistModelAssembler = mockk<ChecklistModelAssembler>();
-    private val user = User(id = 101, username = "Max Muster", subject = "auth|54321")
+    private val user = User(id = 101, subject = "auth|54321")
 
     @BeforeEach
     fun setUp() {

--- a/src/test/kotlin/ch/ascendise/todolistapi/checklist/ChecklistIT.kt
+++ b/src/test/kotlin/ch/ascendise/todolistapi/checklist/ChecklistIT.kt
@@ -39,8 +39,8 @@ internal class ChecklistIT {
     private lateinit var jackson: ObjectMapper
     private lateinit var jwt: Jwt
 
-    private val user = User(username = "Reanu Keeves", subject = "auth-oauth2|123451234512345")
-    private val otherUser = User(username = "AidenPierce", subject = "auth-oauth2|543215432154321")
+    private val user = User(subject = "auth-oauth2|123451234512345")
+    private val otherUser = User(subject = "auth-oauth2|543215432154321")
     private val checklists = listOf(
         Checklist(name = "Checklist1", user = user, tasks = mutableListOf(
             Task(name = "Task1-1", user = user),
@@ -63,9 +63,8 @@ internal class ChecklistIT {
     fun getJwt(): Jwt {
         val jwt = mockk<Jwt>()
         every { jwt.subject }.returns(user.subject)
-        every { jwt.getClaimAsString("name")}.returns(user.username)
         every { jwt.hasClaim(any())}.answers { callOriginal() }
-        every { jwt.claims}.returns(mapOf( "name" to user.username, "sub" to user.subject))
+        every { jwt.claims}.returns(mapOf( "sub" to user.subject))
         return jwt
     }
 

--- a/src/test/kotlin/ch/ascendise/todolistapi/checklist/ChecklistIT.kt
+++ b/src/test/kotlin/ch/ascendise/todolistapi/checklist/ChecklistIT.kt
@@ -10,7 +10,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
+import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import org.hamcrest.core.Is.`is`
 import org.junit.jupiter.api.AfterEach
@@ -21,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
@@ -36,6 +39,7 @@ internal class ChecklistIT {
     @Autowired private lateinit var userRepository: UserRepository
     @Autowired private lateinit var checklistRepository: ChecklistRepository
     @Autowired private lateinit var taskRepository: TaskRepository
+    @MockkBean private lateinit var jwtDecoder: JwtDecoder
     private lateinit var jackson: ObjectMapper
     private lateinit var jwt: Jwt
 

--- a/src/test/kotlin/ch/ascendise/todolistapi/checklist/ChecklistModelAssemblerTest.kt
+++ b/src/test/kotlin/ch/ascendise/todolistapi/checklist/ChecklistModelAssemblerTest.kt
@@ -14,7 +14,7 @@ import org.springframework.hateoas.server.mvc.linkTo
 
 internal class ChecklistModelAssemblerTest
 {
-    private val user = User(id = 101, username = "User User", subject="auth|12345")
+    private val user = User(id = 101, subject="auth|12345")
     private lateinit var checklistModelAssembler: ChecklistModelAssembler
 
     @BeforeEach

--- a/src/test/kotlin/ch/ascendise/todolistapi/checklist/ChecklistServiceTest.kt
+++ b/src/test/kotlin/ch/ascendise/todolistapi/checklist/ChecklistServiceTest.kt
@@ -17,7 +17,7 @@ internal class ChecklistServiceTest {
 
     private val checklistRepository = mockk<ChecklistRepository>()
     private val taskService = mockk<TaskService>()
-    private val user = User(id = 100, username = "user", subject = "auth-oauth2|123451234512345")
+    private val user = User(id = 100, subject = "auth-oauth2|123451234512345")
     private lateinit var service: ChecklistService
 
     @BeforeEach

--- a/src/test/kotlin/ch/ascendise/todolistapi/checklisttask/ChecklistTaskControllerTest.kt
+++ b/src/test/kotlin/ch/ascendise/todolistapi/checklisttask/ChecklistTaskControllerTest.kt
@@ -26,7 +26,7 @@ internal class ChecklistTaskControllerTest {
     private val checklistTaskModelAssembler = ChecklistTaskModelAssembler()
     private val checklistModelAssembler = ChecklistModelAssembler(TaskModelAssembler())
 
-    private val user = User(id = 101, username = "Nico Nussmueller", subject = "auth|120104")
+    private val user = User(id = 101, subject = "auth|120104")
 
     @BeforeEach
     fun setUp() {
@@ -72,7 +72,7 @@ internal class ChecklistTaskControllerTest {
     }
 
     private fun addExpectedLinks(dto: ChecklistTaskResponseDto): ChecklistTaskResponseDto {
-        val dummyUser = User(id = 101, username = "", subject = "")
+        val dummyUser = User(id = 101, subject = "")
         return dto.add(
             linkTo<ChecklistController> { getChecklist(dto.checklistId, dummyUser) }.withRel("checklist"),
             linkTo<TaskController> { getTask(dummyUser, dto.taskId) }.withRel("task"),

--- a/src/test/kotlin/ch/ascendise/todolistapi/checklisttask/ChecklistTaskIT.kt
+++ b/src/test/kotlin/ch/ascendise/todolistapi/checklisttask/ChecklistTaskIT.kt
@@ -43,7 +43,7 @@ internal class ChecklistTaskIT {
     @Autowired private lateinit var checklistRepository: ChecklistRepository
     private lateinit var jackson: ObjectMapper
     private lateinit var jwt: Jwt
-    private var user = User(id = 0, username = "Max Muster", subject = "auth|12345")
+    private var user = User(id = 0, subject = "auth|12345")
     private var checklist = Checklist(name = "My Checklist", user = user, tasks = mutableListOf(
         Task(name = "My Task 1", user = user),
         Task(name = "My Task 2", user = user)
@@ -63,9 +63,8 @@ internal class ChecklistTaskIT {
     fun getJwt(): Jwt {
         val jwt = mockk<Jwt>()
         every { jwt.subject }.returns(user.subject)
-        every { jwt.getClaimAsString("name")}.returns(user.username)
         every { jwt.hasClaim(any())}.answers { callOriginal() }
-        every { jwt.claims}.returns(mapOf( "name" to user.username, "sub" to user.subject))
+        every { jwt.claims}.returns(mapOf("sub" to user.subject))
         return jwt
     }
 

--- a/src/test/kotlin/ch/ascendise/todolistapi/checklisttask/ChecklistTaskIT.kt
+++ b/src/test/kotlin/ch/ascendise/todolistapi/checklisttask/ChecklistTaskIT.kt
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import io.mockk.mockk
 import org.hamcrest.core.Is
@@ -25,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
 import org.springframework.test.web.servlet.MockMvc
 import javax.transaction.Transactional
@@ -41,6 +43,7 @@ internal class ChecklistTaskIT {
     @Autowired private lateinit var userRepository: UserRepository
     @Autowired private lateinit var taskRepository: TaskRepository
     @Autowired private lateinit var checklistRepository: ChecklistRepository
+    @MockkBean private lateinit var jwtDecoder: JwtDecoder
     private lateinit var jackson: ObjectMapper
     private lateinit var jwt: Jwt
     private var user = User(id = 0, subject = "auth|12345")

--- a/src/test/kotlin/ch/ascendise/todolistapi/checklisttask/ChecklistTaskModelAssemblerTest.kt
+++ b/src/test/kotlin/ch/ascendise/todolistapi/checklisttask/ChecklistTaskModelAssemblerTest.kt
@@ -15,7 +15,7 @@ internal class ChecklistTaskModelAssemblerTest
 
     @Test
     fun `should add links to entity`() {
-        val dummyUser = User(-1, "", "")
+        val dummyUser = User(-1, "")
         val checklistTask = ChecklistTaskResponseDto(taskId = 201, checklistId = 301)
         val checklistTaskWithLinks = modelAssembler.toModel(checklistTask)
         val expectedEntity = ChecklistTaskResponseDto(taskId = 201, checklistId = 301).apply {

--- a/src/test/kotlin/ch/ascendise/todolistapi/checklisttask/ChecklistTaskServiceTest.kt
+++ b/src/test/kotlin/ch/ascendise/todolistapi/checklisttask/ChecklistTaskServiceTest.kt
@@ -20,7 +20,7 @@ internal class ChecklistTaskServiceTest {
     private val taskRepo = mockk<TaskRepository>()
     private val checklistRepo =  mockk<ChecklistRepository>()
 
-    private val user = User(id = 100, username = "user", subject = "auth-oauth2|123451234512345")
+    private val user = User(id = 100, subject = "auth-oauth2|123451234512345")
 
     @BeforeEach
     fun setUp() {

--- a/src/test/kotlin/ch/ascendise/todolistapi/home/HomeControllerTest.kt
+++ b/src/test/kotlin/ch/ascendise/todolistapi/home/HomeControllerTest.kt
@@ -14,7 +14,7 @@ import org.springframework.hateoas.server.mvc.linkTo
 internal class HomeControllerTest {
 
     private val controller = HomeController()
-    private val user = User(id = 101, username = "John Doe", subject = "auth|123456789")
+    private val user = User(id = 101, subject = "auth|123456789")
 
     @Test
     fun `should return links to all resources`() {

--- a/src/test/kotlin/ch/ascendise/todolistapi/home/HomeIT.kt
+++ b/src/test/kotlin/ch/ascendise/todolistapi/home/HomeIT.kt
@@ -27,7 +27,7 @@ internal class HomeIT {
     @Autowired private lateinit var mockMvc: MockMvc
     @Autowired private lateinit var userRepository: UserRepository
 
-    private val user = User(id = 100, username = "user", subject = "auth-oauth2|123451234512345")
+    private val user = User(id = 100, subject = "auth-oauth2|123451234512345")
     private val jwt = mockk<Jwt>()
 
     @BeforeEach
@@ -43,9 +43,8 @@ internal class HomeIT {
 
     private fun setUpMockJwt() {
         every { jwt.subject }.returns(user.subject)
-        every { jwt.getClaimAsString("given_name") }.returns(user.username)
         every { jwt.hasClaim(any()) }.answers { callOriginal() }
-        every { jwt.claims }.returns(mapOf("name" to user.username, "sub" to user.subject))
+        every { jwt.claims }.returns(mapOf("sub" to user.subject))
     }
 
     @Test

--- a/src/test/kotlin/ch/ascendise/todolistapi/home/HomeIT.kt
+++ b/src/test/kotlin/ch/ascendise/todolistapi/home/HomeIT.kt
@@ -2,6 +2,7 @@ package ch.ascendise.todolistapi.home
 
 import ch.ascendise.todolistapi.user.User
 import ch.ascendise.todolistapi.user.UserRepository
+import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import io.mockk.mockk
 import org.hamcrest.core.Is
@@ -12,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.test.context.support.WithAnonymousUser
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt
 import org.springframework.test.web.servlet.MockMvc
@@ -26,6 +28,7 @@ internal class HomeIT {
 
     @Autowired private lateinit var mockMvc: MockMvc
     @Autowired private lateinit var userRepository: UserRepository
+    @MockkBean private lateinit var jwtDecoder: JwtDecoder
 
     private val user = User(id = 100, subject = "auth-oauth2|123451234512345")
     private val jwt = mockk<Jwt>()

--- a/src/test/kotlin/ch/ascendise/todolistapi/task/TaskControllerTest.kt
+++ b/src/test/kotlin/ch/ascendise/todolistapi/task/TaskControllerTest.kt
@@ -19,7 +19,7 @@ internal class TaskControllerTest {
     private lateinit var controller: TaskController
     private val taskService = mockk<TaskService>()
     private val taskModelAssembler = TaskModelAssembler()
-    private val user = User(id = 101, username = "John Doe", subject = "auth|12345")
+    private val user = User(id = 101, subject = "auth|12345")
 
     @BeforeEach
     fun setUp() {

--- a/src/test/kotlin/ch/ascendise/todolistapi/task/TaskIT.kt
+++ b/src/test/kotlin/ch/ascendise/todolistapi/task/TaskIT.kt
@@ -40,8 +40,8 @@ internal class TaskIT {
     @Autowired private lateinit var taskRepository: TaskRepository
     @Autowired private lateinit var checklistRepository: ChecklistRepository
     private lateinit var jackson: ObjectMapper
-    private val user = User(username = "Reanu Keeves", subject = "auth-oauth2|123451234512345")
-    private val otherUser = User(username = "AidenPierce", subject = "auth-oauth2|543215432154321")
+    private val user = User(subject = "auth-oauth2|123451234512345")
+    private val otherUser = User(subject = "auth-oauth2|543215432154321")
     private val tasks = setOf(Task(name = "Buy bread", description = "Wholegrain", user = user),
         Task(name = "Do Taxes", startDate = LocalDate.now(), endDate = LocalDate.now().plusDays(30), user = user)
     )
@@ -88,9 +88,8 @@ internal class TaskIT {
     fun getJwt(user: User): Jwt {
         val jwt = mockk<Jwt>()
         every { jwt.subject }.returns(user.subject)
-        every { jwt.getClaimAsString("name")}.returns(user.username)
         every { jwt.hasClaim(any())}.answers { callOriginal() }
-        every { jwt.claims}.returns(mapOf( "name" to user.username, "sub" to user.subject))
+        every { jwt.claims}.returns(mapOf("sub" to user.subject))
         return jwt
     }
 

--- a/src/test/kotlin/ch/ascendise/todolistapi/task/TaskIT.kt
+++ b/src/test/kotlin/ch/ascendise/todolistapi/task/TaskIT.kt
@@ -10,7 +10,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
+import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import org.hamcrest.core.Is.`is`
 import org.junit.jupiter.api.AfterEach
@@ -21,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt
 import org.springframework.test.web.servlet.MockMvc
@@ -39,6 +42,7 @@ internal class TaskIT {
     @Autowired private lateinit var userRepository: UserRepository
     @Autowired private lateinit var taskRepository: TaskRepository
     @Autowired private lateinit var checklistRepository: ChecklistRepository
+    @MockkBean private lateinit var jwtDecoder: JwtDecoder
     private lateinit var jackson: ObjectMapper
     private val user = User(subject = "auth-oauth2|123451234512345")
     private val otherUser = User(subject = "auth-oauth2|543215432154321")

--- a/src/test/kotlin/ch/ascendise/todolistapi/task/TaskModelAssemblerTest.kt
+++ b/src/test/kotlin/ch/ascendise/todolistapi/task/TaskModelAssemblerTest.kt
@@ -17,7 +17,7 @@ internal class TaskModelAssemblerTest {
 
     @Test
     fun `should return task with links to specific operations`() {
-        val user = User(id = 101, username = "Jane Doe", subject = "auth|54321")
+        val user = User(id = 101, subject = "auth|54321")
         val task = Task(id = 201, name = "Task1", description = "My new task", user = user)
         val taskWithLinks = taskModelAssembler.toModel(task)
         val expectedTaskWithLinks = TaskResponseDto(id = 201, name = "Task1", description = "My new task").let {
@@ -29,7 +29,7 @@ internal class TaskModelAssemblerTest {
 
     @Test
     fun `should return TaskResponseDto with links to specific operation`() {
-        val user = User(id = 101, username = "Jane Doe", subject = "auth|54321")
+        val user = User(id = 101, subject = "auth|54321")
         val taskResponse = TaskResponseDto(id = 201, name = "Task1", description = "My new task")
         val taskResponseWithLinks = taskModelAssembler.toModel(taskResponse, user)
         val expectedTaskResponseWihtLink = TaskResponseDto(id = 201, name = "Task1", description = "My new task").let {

--- a/src/test/kotlin/ch/ascendise/todolistapi/task/TaskServiceTest.kt
+++ b/src/test/kotlin/ch/ascendise/todolistapi/task/TaskServiceTest.kt
@@ -33,7 +33,7 @@ internal class TaskServiceTest {
             description = "Test TaskService",
             startDate = LocalDate.now(),
             endDate = LocalDate.now().plusDays(1),
-            user = User(username = "", subject = "")
+            user = User(subject = "")
         )
         every { taskRepository.save(task) } returns task
         service.create(task)
@@ -48,7 +48,7 @@ internal class TaskServiceTest {
             description = "Test TaskService",
             startDate = LocalDate.now().plusDays(1),
             endDate = LocalDate.now(),
-            user = User(username = "", subject = "")
+            user = User(subject = "")
         )
         assertThrows<InvalidDateRangeTaskException> { service.create(task) }
     }
@@ -60,7 +60,7 @@ internal class TaskServiceTest {
             name = "",
             description = "",
             endDate = null,
-            user = User(username = "", subject = "")
+            user = User(subject = "")
         )
         every { taskRepository.save(task) } returns task
         service.create(task)
@@ -74,7 +74,7 @@ internal class TaskServiceTest {
             name = "",
             description = "",
             startDate = LocalDate.now().plusDays(1),
-            user = User(username = "", subject = "")
+            user = User(subject = "")
         )
         every { taskRepository.save(task) } returns task
         service.create(task)
@@ -88,7 +88,7 @@ internal class TaskServiceTest {
             name = "",
             description = "",
             startDate = LocalDate.now().minusDays(1),
-            user = User(username = "", subject = "")
+            user = User(subject = "")
         )
         assertThrows<InvalidTaskException> { service.create(task) }
     }
@@ -96,7 +96,7 @@ internal class TaskServiceTest {
     @Test
     fun `should return tasks for given user`()
     {
-        val user = User(id = 101, username = "John Doe", subject = "auth|12345")
+        val user = User(id = 101, subject = "auth|12345")
         val task1 = Task(id = 201, name = "Task1", description = "Task1", startDate = LocalDate.now(), user = user)
         val task2 = Task(id = 202, name = "Task2", description = "Task2", endDate = LocalDate.now(), user = user)
         every { taskRepository.findAllByUserId(101) } returns listOf(task1, task2)
@@ -118,7 +118,7 @@ internal class TaskServiceTest {
 
     @Test
     fun `should return task with given user id`() {
-        val user = User(id = 101, subject = "auth-oauth2|123451234512345", username = "Max")
+        val user = User(id = 101, subject = "auth-oauth2|123451234512345")
         val task = Task(id = 201, name = "Dummy", user = user)
         every { taskRepository.findByIdAndUserId(task.id, user.id)} returns Optional.of(task)
         val returnedTask = service.getById(user.id, task.id)
@@ -128,14 +128,14 @@ internal class TaskServiceTest {
 
     @Test
     fun `should throw exception when task is not found`() {
-        val user = User(id = 101, subject = "auth-oauth2|123451234512345", username = "Max")
+        val user = User(id = 101, subject = "auth-oauth2|123451234512345")
         every { taskRepository.findByIdAndUserId(201, user.id) } returns Optional.empty()
         assertThrows<TaskNotFoundException> { service.getById(user.id, 201) }
     }
 
     @Test
     fun `should allow task with start date in past when updating`() {
-        val user = User(id = 101, subject = "auth-oauth2|123451234512345", username = "Max")
+        val user = User(id = 101, subject = "auth-oauth2|123451234512345")
         val oldTask = Task(id = 201, name = "Old Task", description = "This task has an old description",
             startDate = LocalDate.now().minusDays(1), isDone = false, user = user)
         val newTask = Task(id = 201, name = "Updated Task", description = "This task has a new description",
@@ -149,7 +149,7 @@ internal class TaskServiceTest {
 
     @Test
     fun `should update task`() {
-        val user = User(id = 101, subject = "auth-oauth2|123451234512345", username = "Max")
+        val user = User(id = 101, subject = "auth-oauth2|123451234512345")
         val oldTask = Task(id = 201, name = "Old Task", description = "This task has an old description", isDone = false, user = user)
         val newTask = Task(id = 201, name = "Updated Task", description = "This task has a new description", isDone = true, user = user)
         every { taskRepository.findByIdAndUserId(oldTask.id, user.id) } returns Optional.of(oldTask)
@@ -162,7 +162,7 @@ internal class TaskServiceTest {
 
     @Test
     fun `should throw TaskNotFoundException when task to be updated was not found`() {
-        val user = User(id = 101, subject = "auth-oauth2|123451234512345", username = "Max")
+        val user = User(id = 101, subject = "auth-oauth2|123451234512345")
         val task = Task(id = 201, name = "Updated Task", description = "This task has a new description", user = user)
         every { taskRepository.findByIdAndUserId(task.id, user.id) } returns Optional.empty()
         assertThrows<TaskNotFoundException> { service.update(task) }
@@ -171,7 +171,7 @@ internal class TaskServiceTest {
 
     @Test
     fun `should throw InvalidDateRangeTaskException if updated task has start date before end date `() {
-        val user = User(id = 101, subject = "auth-oauth2|123451234512345", username = "Max")
+        val user = User(id = 101, subject = "auth-oauth2|123451234512345")
         val oldTask = Task(id = 201, name = "Old Task", user = user)
         val task = Task(id = 201, name = "Updated Task", user = user, endDate = LocalDate.now().minusDays(1))
         every { taskRepository.findByIdAndUserId(task.id, user.id) } returns Optional.of(oldTask)
@@ -182,7 +182,7 @@ internal class TaskServiceTest {
     @Test
     fun `should throw InvalidDateRangeTaskException if new start date is before old start date`() {
 
-        val user = User(id = 101, subject = "auth-oauth2|123451234512345", username = "Max")
+        val user = User(id = 101, subject = "auth-oauth2|123451234512345")
         val oldTask = Task(id = 201, name = "Old Task", user = user, startDate = LocalDate.now().plusDays(2))
         val task = Task(id = 201, name = "Updated Task", user = user, endDate = LocalDate.now().plusDays(1))
         every { taskRepository.findByIdAndUserId(task.id, user.id) } returns Optional.of(oldTask)

--- a/src/test/kotlin/ch/ascendise/todolistapi/user/AudienceValidatorTest.kt
+++ b/src/test/kotlin/ch/ascendise/todolistapi/user/AudienceValidatorTest.kt
@@ -1,0 +1,53 @@
+package ch.ascendise.todolistapi.user
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.core.OAuth2Error
+import org.springframework.security.oauth2.jwt.Jwt
+
+internal class AudienceValidatorTest {
+
+    @Test
+    fun `validate(jwt) should return success if audience matches configured audience`() {
+        //Arrange
+        val validator = AudienceValidator("my-app-audience")
+        val token = mockk<Jwt>();
+        every { token.audience } returns listOf("my-app-audience")
+        //Act
+        val result = validator.validate(token)
+        //Assert
+        assertFalse(result.hasErrors())
+    }
+
+    @Test
+    fun `validate(jwt) should return error if audience is not matching`() {
+        //Arrange
+        val validator = AudienceValidator("my-app-audience")
+        val token = mockk<Jwt>()
+        every { token.audience } returns listOf("wrong-app-audience")
+        //Act
+        val result = validator.validate(token)
+        //Assert
+        assertTrue(result.hasErrors())
+        assertEquals(1, result.errors.size)
+        val error = result.errors.first()
+        assertEquals("invalid_token", error.errorCode)
+        assertEquals("The required audience is missing", error.description)
+    }
+
+    @Test
+    fun `validate(jwt) should return failure if token is null`() {
+        //Arrange
+        val validator = AudienceValidator("my-app-audience")
+        //Act
+        val result = validator.validate(null)
+        //Assert
+        assertTrue(result.hasErrors())
+        assertEquals(1, result.errors.size)
+        val error = result.errors.first()
+        assertEquals("invalid_token", error.errorCode)
+        assertEquals("The required audience is missing", error.description)
+    }
+}

--- a/src/test/kotlin/ch/ascendise/todolistapi/user/PostAuthenticationHandlerTest.kt
+++ b/src/test/kotlin/ch/ascendise/todolistapi/user/PostAuthenticationHandlerTest.kt
@@ -21,15 +21,13 @@ internal class PostAuthenticationHandlerTest
         val event = mockk<AuthenticationSuccessEvent>()
         val jwt = mockk<Jwt>()
         every { event.authentication.principal } returns jwt
-        every { jwt.getClaimAsString("name") } returns "John Doe"
         every { jwt.subject } returns "auth|12345"
         every { userRepository.existsBySubject("auth|12345") } returns false
-        val expectedCreatedUser = User(id = 0, username = "John Doe", subject = "auth|12345")
+        val expectedCreatedUser = User(id = 0, subject = "auth|12345")
         every { userRepository.save(expectedCreatedUser) } returns expectedCreatedUser
         postAuthHandler.onApplicationEvent(event)
         verifyAll {
             event.authentication.principal
-            jwt.getClaimAsString("name")
             jwt.subject
             userRepository.existsBySubject("auth|12345")
             userRepository.save(expectedCreatedUser)
@@ -41,15 +39,13 @@ internal class PostAuthenticationHandlerTest
         val event = mockk<AuthenticationSuccessEvent>()
         val jwt = mockk<Jwt>()
         every { event.authentication.principal } returns jwt
-        every { jwt.getClaimAsString("name") } returns "John Doe"
         every { jwt.subject } returns "auth|12345"
         every { userRepository.existsBySubject("auth|12345") } returns true
-        val expectedCreatedUser = User(id = 0, username = "John Doe", subject = "auth|12345")
+        val expectedCreatedUser = User(id = 0, subject = "auth|12345")
         every { userRepository.save(expectedCreatedUser) } returns expectedCreatedUser
         postAuthHandler.onApplicationEvent(event)
         verifyAll{
             event.authentication.principal
-            jwt.getClaimAsString("name")
             jwt.subject
             userRepository.existsBySubject("auth|12345")
         }

--- a/src/test/kotlin/ch/ascendise/todolistapi/user/UserControllerTest.kt
+++ b/src/test/kotlin/ch/ascendise/todolistapi/user/UserControllerTest.kt
@@ -29,17 +29,17 @@ internal class UserControllerTest {
         val subject = "auth|12345"
         val jwt = mockk<Jwt>()
         every { jwt.subject } returns subject
-        val expectedUser = User(id = 101, username = "John Doe", subject = subject)
+        val expectedUser = User(id = 101, subject = subject)
         expectedUser.add(linkTo<UserController> { getCurrentUser(expectedUser) }.withSelfRel())
         expectedUser.add(linkTo<UserController> { getCurrentUser(expectedUser) }.withRel("user"))
-        val user = User(id = 101, username = "John Doe", subject = subject)
+        val user = User(id = 101, subject = subject)
         val actualUser = controller.getCurrentUser(user)
         assertEquals(expectedUser, actualUser)
     }
 
     @Test
     fun `should delete user and return a NO CONTENT status`() {
-        val user =  User(id = 101, username = "John Doe", subject = "auth|12345")
+        val user =  User(id = 101, subject = "auth|12345")
         justRun { userService.delete(user) }
         val response = controller.deleteCurrentUser(user)
         assertEquals(HttpStatus.NO_CONTENT, response.statusCode)

--- a/src/test/kotlin/ch/ascendise/todolistapi/user/UserIT.kt
+++ b/src/test/kotlin/ch/ascendise/todolistapi/user/UserIT.kt
@@ -50,7 +50,7 @@ class UserIT {
 
     @Test
     fun `should return info of current user`() {
-        val expectedUser = User(subject = "auth-oauth2|123451234512345", username = "Max Muster")
+        val expectedUser = User(subject = "auth-oauth2|123451234512345")
         userRepository.save(expectedUser)
         val jwt = getJwt(expectedUser)
         val result = mockMvc.perform(
@@ -59,22 +59,20 @@ class UserIT {
             .andExpect(status().is2xxSuccessful)
             .andReturn().response.contentAsString
         assertAll({result.contains(expectedUser.subject)},
-            {result.contains(expectedUser.username)},
             {result.contains(expectedUser.id.toString())})
     }
 
     private fun getJwt(user: User): Jwt {
         val jwt = mockk<Jwt>()
         every { jwt.subject }.returns(user.subject)
-        every { jwt.getClaimAsString("name")}.returns(user.username)
         every { jwt.hasClaim(any())}.answers { callOriginal() }
-        every { jwt.claims}.returns(mapOf( "name" to user.username, "sub" to user.subject))
+        every { jwt.claims}.returns(mapOf( "sub" to user.subject))
         return jwt
     }
 
     @Test
     fun `should delete user`() {
-        var user = User(id = 1, subject=  "auth-oauth2|123451234512345", username = "name")
+        var user = User(id = 1, subject=  "auth-oauth2|123451234512345")
         userRepository.save(user)
         user = userRepository.findBySubject("auth-oauth2|123451234512345")
         val jwt = getJwt(user)
@@ -93,7 +91,7 @@ class UserIT {
 
     @Test
     fun `should have empty response body on DELETE request`() {
-        val user = User(subject = "auth-oauth2|123451234512345", username = "name")
+        val user = User(subject = "auth-oauth2|123451234512345")
         userRepository.save(user)
         val jwt = getJwt(user)
         val result = mockMvc.perform(
@@ -107,7 +105,7 @@ class UserIT {
 
     @Test
     fun `should show available operations for user`() {
-        val expectedUser = User(subject = "auth-oauth2|123451234512345", username = "Max Muster")
+        val expectedUser = User(subject = "auth-oauth2|123451234512345")
         userRepository.save(expectedUser)
         val jwt = getJwt(expectedUser)
         mockMvc.perform(

--- a/src/test/kotlin/ch/ascendise/todolistapi/user/UserIT.kt
+++ b/src/test/kotlin/ch/ascendise/todolistapi/user/UserIT.kt
@@ -4,6 +4,7 @@ import ch.ascendise.todolistapi.checklist.Checklist
 import ch.ascendise.todolistapi.checklist.ChecklistService
 import ch.ascendise.todolistapi.task.Task
 import ch.ascendise.todolistapi.task.TaskService
+import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import io.mockk.mockk
 import org.hamcrest.core.Is.`is`
@@ -15,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.test.context.support.WithAnonymousUser
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt
@@ -34,6 +36,7 @@ class UserIT {
     @Autowired private lateinit var userRepository: UserRepository
     @Autowired private lateinit var taskService: TaskService
     @Autowired private lateinit var checklistService: ChecklistService
+    @MockkBean private lateinit var jwtDecoder: JwtDecoder
 
     @AfterEach
     fun tearDown() {

--- a/src/test/kotlin/ch/ascendise/todolistapi/user/UserModelAssemblerTest.kt
+++ b/src/test/kotlin/ch/ascendise/todolistapi/user/UserModelAssemblerTest.kt
@@ -17,7 +17,7 @@ internal class UserModelAssemblerTest {
 
     @Test
     fun `should add links to user`() {
-        val user = User(id = 101, subject = "auth|12345", username = "John Doe")
+        val user = User(id = 101, subject = "auth|12345")
         val userWithLinks = modelAssembler.toModel(user)
         assertEquals(2, userWithLinks.links.count())
         assertEquals("/user", userWithLinks.links.getLink("self").get().href)

--- a/src/test/kotlin/ch/ascendise/todolistapi/user/UserServiceTest.kt
+++ b/src/test/kotlin/ch/ascendise/todolistapi/user/UserServiceTest.kt
@@ -28,7 +28,7 @@ internal class UserServiceTest {
         val subject = "auth|12345"
         val jwt = mockk<Jwt>()
         every { jwt.subject } returns subject
-        val expectedUser = User(id = 101, subject = subject, username = "John Doe")
+        val expectedUser = User(id = 101, subject = subject)
         every { userRepository.findBySubject(subject) } returns expectedUser
         val actualUser = service.getUser(jwt)
         assertEquals(expectedUser, actualUser)
@@ -40,7 +40,7 @@ internal class UserServiceTest {
 
     @Test
     fun `should delete user and all associated ressources`() {
-        val user = User(id = 101, subject = "auth|12345", username = "John Doe")
+        val user = User(id = 101, subject = "auth|12345")
         val checklists = listOf(
             Checklist(id = 301, name = "Checklist 1", user = user),
             Checklist(id = 302, name = "Checklist 2", user = user)

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: issuer-uri
+          issuer-uri: https://auth.provider.com
           jwk-set-uri:  http://authorization-server.dev/.well-known/jwks.json
 oauth2:
   audience: https://aud.myapi.com

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -5,3 +5,5 @@ spring:
         jwt:
           issuer-uri: issuer-uri
           jwk-set-uri:  http://authorization-server.dev/.well-known/jwks.json
+oauth2:
+  audience: https://aud.myapi.com


### PR DESCRIPTION
BREAKING CHANGE: 

This change mostly contains changes to how the JWT is validated.

API now validates the aud-claim, which means clients that for some reason send a JWT that has a different aud-claim will now be rejected.
Furthermore, the username property was removed from the User-Resource. As the required claim is not standardized and normally contained in the id_token and not in the access_token. You should send the access_token anyway...
